### PR TITLE
feature enctrypted EFS

### DIFF
--- a/coderunners/app.py
+++ b/coderunners/app.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 
 from models import SubmissionRequest, SubmissionResult
@@ -13,5 +14,11 @@ def run_code_lambda(event, context):
     request = SubmissionRequest.from_dict(event)
     print('ALl the params:', request)
 
-    results: SubmissionResult = check_code(**request.__dict__)
+    # Clear the data so that the sensitive information does not propagate to subprocesses
+    encryption_key = os.environb.pop(b'ENCRYPTION_KEY') if 'ENCRYPTION_KEY' in os.environ else None
+    print('encryption key:', encryption_key)
+
+    results: SubmissionResult = check_code(**request.__dict__, encryption_key=encryption_key)
+    if encryption_key:  # Lambda can be reused => keep the state unchanged
+        os.environb[b'ENCRYPTION_KEY'] = encryption_key
     return results.to_json()

--- a/coderunners/models.py
+++ b/coderunners/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, List, Union, Dict
+from typing import Optional, Union
 
 from dataclasses_json import dataclass_json, LetterCase
 
@@ -26,7 +26,7 @@ class TestCase:
 @dataclass
 class SubmissionRequest:
     # Code is a mapping from filename.extension -> content (Http requests have 2MB limit)
-    code: Dict[str, str]
+    code: dict[str, str]
     language: str
     memory_limit: int = 512     # MB
     time_limit: int = 5         # seconds
@@ -35,7 +35,7 @@ class SubmissionRequest:
     # Provide either problem (which is used to find the test cases in the s3 bucket)
     # Or provide the test cases as a list of TestCases directly
     problem: Optional[str] = None
-    test_cases: Optional[List[TestCase]] = None
+    test_cases: Optional[list[TestCase]] = None
 
     aggregate_results: bool = True
     return_outputs: bool = False
@@ -57,13 +57,13 @@ class SubmissionRequest:
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class SubmissionResult:
-    status: Union[Status, List[Status]]
-    memory: Union[float, List[float]]
-    time: Union[float, List[float]]
+    status: Union[Status, list[Status]]
+    memory: Union[float, list[float]]
+    time: Union[float, list[float]]
     score: float
     message: Optional[str] = None
-    outputs: Union[str, List[str], None] = None
-    errors: Union[str, List[str], None] = None
+    outputs: Union[str, list[str], None] = None
+    errors: Union[str, list[str], None] = None
     compile_outputs: Optional[str] = None
 
 

--- a/coderunners/process.py
+++ b/coderunners/process.py
@@ -36,7 +36,6 @@ class Process:
     finish_time: float = time.time()
     memory_limit: int = field(init=False)
     output_limit: int = field(init=False)
-    user: Optional[int] = None
 
     def __post_init__(self):
         self.memory_limit = self.memory_limit_mb * 1024 * 1024
@@ -52,7 +51,6 @@ class Process:
             self.command, shell=True,
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
             preexec_fn=lambda: limit_resources(max_bytes=self.memory_limit),
-            user=self.user,
         )
         self.execution_state = True
 
@@ -61,7 +59,8 @@ class Process:
         try:
             self.execute()
             if program_input:
-                self.p.stdin.write(program_input + '\n')
+                end = '' if program_input.endswith('\n') else '\n'  # Otherwise, the program hangs
+                self.p.stdin.write(program_input + end)
                 self.p.stdin.flush()
 
             # poll as often as possible; otherwise the subprocess might

--- a/coderunners/requirements.txt
+++ b/coderunners/requirements.txt
@@ -1,2 +1,3 @@
 dataclasses-json>=0.5.6
 psutil>=5.9.0
+cryptography>=36.0.1

--- a/coderunners/util.py
+++ b/coderunners/util.py
@@ -1,4 +1,5 @@
 import errno
+from pathlib import Path
 
 
 def is_float(value: str) -> bool:
@@ -17,3 +18,14 @@ def return_code2status(code: int) -> str:
     if code == 139:     return 'SIGSEGV'
     if code == 143:     return 'SIGTERM'
     return ''
+
+
+def save_code(save_dir: Path, code: dict[str, str]) -> list[Path]:
+    saved_paths: list[Path] = []
+    for filename, content in code.items():
+        path = save_dir / filename
+        saved_paths.append(path)
+        with open(path, 'w') as f:
+            f.write(content)
+
+    return saved_paths

--- a/judges/models.py
+++ b/judges/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, List, Union, Dict
+from typing import Optional, Union
 
 from dataclasses_json import dataclass_json, LetterCase
 
@@ -26,7 +26,7 @@ class TestCase:
 @dataclass
 class SubmissionRequest:
     # Code is a mapping from filename.extension -> content (Http requests have 2MB limit)
-    code: Dict[str, str]
+    code: dict[str, str]
     language: str
     memory_limit: int = 512     # MB
     time_limit: int = 5         # seconds
@@ -35,7 +35,7 @@ class SubmissionRequest:
     # Provide either problem (which is used to find the test cases in the s3 bucket)
     # Or provide the test cases as a list of TestCases directly
     problem: Optional[str] = None
-    test_cases: Optional[List[TestCase]] = None
+    test_cases: Optional[list[TestCase]] = None
 
     aggregate_results: bool = True
     return_outputs: bool = False
@@ -58,11 +58,11 @@ class SubmissionRequest:
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class SubmissionResult:
-    status: Union[Status, List[Status]]
-    memory: Union[float, List[float]]
-    time: Union[float, List[float]]
+    status: Union[Status, list[Status]]
+    memory: Union[float, list[float]]
+    time: Union[float, list[float]]
     score: float
     message: Optional[str] = None
-    outputs: Union[str, List[str], None] = None
-    errors: Union[str, List[str], None] = None
+    outputs: Union[str, list[str], None] = None
+    errors: Union[str, list[str], None] = None
     compile_outputs: Optional[str] = None


### PR DESCRIPTION
## Overengineering at its finest

Instead of preventing the submitted code from accessing the `EFS` files by setting up user permissions, we just encrypt all the files on the EFS and provide the encryption key to only the parent process of the lambda function. After that, the parent process just removes the key from the environment variables so that none of the subprocesses can have access to it.

--------------
Used https://cryptography.io/en/latest/fernet/ to encrypt and decrypt the data

Provide an encryption key to the main lambda process so that it can decrypt the problem files and prevent the subprocesses from having access to the encryption key

* Created an s3 bucket `lambda-judge-problems` with 2 folders `problems` and `encrypted`
    * `problems` contains the gzipped versions of the problems
    * `encrypted` contains `Fernet` the encrypted versions of the gzip files
* Setted up a DataSync to sync the `lambda-judge-problems/encrypted` to the Lambda EFS
* Provided an environment variable `ENCRYPTION_KEY` in the AWS console for both `CodeRunnerCpp` and `CodeRunnerPython`

Now the coderunner lambda:
* Gets `ENCRYPTION_KEY` as an environment variable
* Removes is from `os.environ` so that its subprocesses do not have access to the key
* Decrypts `.gz.fer` file and passes the decrypted and unzipped version (only input) to the submitted code
* Adds back the `ENCRYPTION_KEY` environment variable as the lambda can be re-used and AWS does not populate the environment variables on each lambda launch


