### PR TITLE
Fix SQL compiler status constant

### DIFF
--- a/coderunners/compilers.py
+++ b/coderunners/compilers.py
@@ -234,7 +234,7 @@ class SQLiteCompiler(Compiler):
     def compile(self, submission_paths: list[Path]):
         if len(submission_paths) != 1:
             return ProcessExecutor(command='echo "Only one file is allowed"'), RunResult(
-                status=Status.CE, memory=0, time=0, return_code=0, outputs=None,
+                status=Status.COMPILATION_ERROR, memory=0, time=0, return_code=0, outputs=None,
                 errors='Only one file is allowed for SQL submissions',
             )
 


### PR DESCRIPTION
## Summary
- use correct Status constant for SQL compile errors

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/unit`
- `pytest -q` *(fails: EndpointConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_683f4485d464832c862865b8d87a36c5